### PR TITLE
Send Notification

### DIFF
--- a/src/services/subscription.service.js
+++ b/src/services/subscription.service.js
@@ -2,7 +2,6 @@ const { loggers } = require('@asymmetrik/node-fhir-server-core');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
 const topiclist = require('../../public/topiclist.json');
-const { sendNotification } = require('../utils/subscriptions');
 
 const logger = loggers.get('default');
 const SUBSCRIPTION = 'subscriptions';
@@ -47,25 +46,6 @@ module.exports.create = (_args, { req }) => {
     if (!resource.id) resource.id = uuidv4();
     db.insert(SUBSCRIPTION, resource);
 
-    // TODO: just for testing purpose remove after PR
-    const encounter = {
-      resourceType: 'Encounter',
-      id: 'enc1',
-      text: {
-        status: 'generated',
-        div: '<div xmlns="http://www.w3.org/1999/xhtml">Encounter with patient @example</div>',
-      },
-      status: 'in-progress',
-      class: {
-        system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
-        code: 'IMP',
-        display: 'inpatient encounter',
-      },
-      subject: {
-        reference: 'Patient/pat01',
-      },
-    };
-    sendNotification([encounter], resource);
     resolve({ id: resource.id });
   });
 };

--- a/src/services/subscription.service.js
+++ b/src/services/subscription.service.js
@@ -2,6 +2,7 @@ const { loggers } = require('@asymmetrik/node-fhir-server-core');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
 const topiclist = require('../../public/topiclist.json');
+const { sendNotification } = require('../utils/subscriptions');
 
 const logger = loggers.get('default');
 const SUBSCRIPTION = 'subscriptions';
@@ -45,6 +46,26 @@ module.exports.create = (_args, { req }) => {
     }
     if (!resource.id) resource.id = uuidv4();
     db.insert(SUBSCRIPTION, resource);
+
+    // TODO: just for testing purpose remove after PR
+    const encounter = {
+      resourceType: 'Encounter',
+      id: 'enc1',
+      text: {
+        status: 'generated',
+        div: '<div xmlns="http://www.w3.org/1999/xhtml">Encounter with patient @example</div>',
+      },
+      status: 'in-progress',
+      class: {
+        system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+        code: 'IMP',
+        display: 'inpatient encounter',
+      },
+      subject: {
+        reference: 'Patient/pat01',
+      },
+    };
+    sendNotification([encounter], resource);
     resolve({ id: resource.id });
   });
 };

--- a/src/utils/subscriptions.js
+++ b/src/utils/subscriptions.js
@@ -1,0 +1,101 @@
+const axios = require('axios');
+const config = require('config');
+const { v4: uuidv4 } = require('uuid');
+const db = require('../storage/DataAccess');
+const fhirServerConfig = config.get('fhirServerConfig').resolve();
+
+const SUBSCRIPTION = 'subscriptions';
+const BACKPORT_TOPIC_EXTENSION =
+  'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical';
+
+/**
+ * Send a notification with the triggering resources as defined in the subscription
+ *
+ * @param {Resource[]} resources - list of triggering resources to send in notification
+ * @param {Subscription} subscription - the subscription resource to send notification
+ * @returns axios post promise
+ */
+function sendNotification(resources, subscription) {
+  const subscriptionStatus = createSubscriptionStatus(subscription);
+
+  const notificationBundle = {
+    resourceType: 'Bundle',
+    id: uuidv4(),
+    meta: {
+      profile: [
+        'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-subscription-notification',
+      ],
+    },
+    type: 'history',
+    entry: [
+      {
+        fullUrl: `${fhirServerConfig.auth.resourceServer}/Parameters/${subscriptionStatus.id}`,
+        resource: subscriptionStatus,
+      },
+    ],
+  };
+
+  resources.forEach((resource) => {
+    notificationBundle.entry.push({
+      fullUrl: `${fhirServerConfig.auth.resourceServer}/${resource.resourceType}/${resource.id}`,
+      resource: resource,
+    });
+  });
+
+  if (subscription.channel.type !== 'rest-hook') {
+    subscription.status = 'error';
+    db.update(
+      SUBSCRIPTION,
+      (s) => s.id === subscription.id,
+      (s) => Object.assign(s, subscription)
+    );
+    throw `Unsupported subscription channel: ${subscription.channel}`;
+  }
+
+  const headers = {};
+  subscription.channel.header.forEach((header) => {
+    const [name, value] = header.split(': ');
+    headers[name] = value;
+  });
+
+  return axios.post(subscription.channel.endpoint, notificationBundle, { headers: headers });
+}
+
+/**
+ * Create the BackportSubscriptionStatus Parameters resource
+ *
+ * @param {Subscription} subscription - the subscription to get the status of
+ * @param {string} type - 'handshake', 'heartbeat', 'event-notification', or 'query-status'
+ * @returns Parameters resource defining the status of the subscription
+ */
+function createSubscriptionStatus(subscription, type) {
+  const topicExtension = subscription.extension.find((e) => e.url === BACKPORT_TOPIC_EXTENSION);
+
+  return {
+    resourceType: 'Parameters',
+    id: uuidv4(),
+    meta: {
+      profile: [
+        'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-subscriptionstatus',
+      ],
+    },
+    parameter: [
+      {
+        name: 'subscription',
+        valueReference: {
+          reference: `${fhirServerConfig.auth.resourceServer}/Subscription/${subscription.id}`,
+        },
+      },
+      {
+        name: 'topic',
+        valueCanonical: topicExtension.valueUri,
+      },
+      {
+        name: 'type',
+        valueCode: type,
+      },
+    ],
+  };
+}
+
+module.exports = { sendNotification, createSubscriptionStatus };


### PR DESCRIPTION
Implement a function to send an R5 Backport Notification. The function takes in a list of triggering resources and a subscription resources. To test it out I added code to the subscription create handler. This way to test it out you can POST a new subscription to the proxy server and it will immediately send a notification the provided endpoint.