### PR TITLE
Send notifications after polling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,7 @@ process.env.ALLOW_CONFIG_MUTATIONS = true;
 
 const config = require('config');
 
-let fhirServerConfig = config.get('fhirServerConfig');
-if (fhirServerConfig.resolve) fhirServerConfig = fhirServerConfig.resolve();
+const fhirServerConfig = config.get('fhirServerConfig');
 
 const main = function () {
   const server = new Server(fhirServerConfig);

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ process.env.ALLOW_CONFIG_MUTATIONS = true;
 
 const config = require('config');
 
-const fhirServerConfig = config.get('fhirServerConfig').resolve();
+let fhirServerConfig = config.get('fhirServerConfig');
+if (fhirServerConfig.resolve) fhirServerConfig = fhirServerConfig.resolve();
 
 const main = function () {
   const server = new Server(fhirServerConfig);

--- a/src/services/subscription.service.js
+++ b/src/services/subscription.service.js
@@ -2,6 +2,7 @@ const { loggers } = require('@asymmetrik/node-fhir-server-core');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
 const topiclist = require('../../public/topiclist.json');
+const { initialPoll } = require('../utils/polling');
 
 const logger = loggers.get('default');
 const SUBSCRIPTION = 'subscriptions';
@@ -45,6 +46,9 @@ module.exports.create = (_args, { req }) => {
     }
     if (!resource.id) resource.id = uuidv4();
     db.insert(SUBSCRIPTION, resource);
+
+    // Initial poll for new subscription
+    initialPoll(resource);
 
     resolve({ id: resource.id });
   });

--- a/src/utils/polling.js
+++ b/src/utils/polling.js
@@ -169,7 +169,7 @@ async function pollSubscriptionTopics() {
             if (storedResource.length === 0) newResources.push(resource);
             else modifiedResources.push(resource);
 
-            db.insert(collection, resource);
+            db.upsert(collection, { id: resource.id }, r => r.id === resource.id);
           });
         }
 

--- a/src/utils/subscriptions.js
+++ b/src/utils/subscriptions.js
@@ -2,7 +2,9 @@ const axios = require('axios');
 const config = require('config');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
-const fhirServerConfig = config.fhirServerConfig;
+
+let fhirServerConfig = config.get('fhirServerConfig');
+if (fhirServerConfig.resolve) fhirServerConfig = fhirServerConfig.resolve();
 
 const SUBSCRIPTION = 'subscriptions';
 const BACKPORT_TOPIC_EXTENSION =

--- a/src/utils/subscriptions.js
+++ b/src/utils/subscriptions.js
@@ -3,8 +3,7 @@ const config = require('config');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
 
-let fhirServerConfig = config.get('fhirServerConfig');
-if (fhirServerConfig.resolve) fhirServerConfig = fhirServerConfig.resolve();
+const fhirServerConfig = config.get('fhirServerConfig');
 
 const SUBSCRIPTION = 'subscriptions';
 const BACKPORT_TOPIC_EXTENSION =

--- a/src/utils/subscriptions.js
+++ b/src/utils/subscriptions.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const config = require('config');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
-const fhirServerConfig = config.get('fhirServerConfig').resolve();
+const fhirServerConfig = config.fhirServerConfig;
 
 const SUBSCRIPTION = 'subscriptions';
 const BACKPORT_TOPIC_EXTENSION =


### PR DESCRIPTION
- Keeps track of new and modified resources before inserting into DB.
- Determines if notifications need to be sent based on the new and modified resources from poll.
    - Currently only sends notifications for `new`, `changed`, and `modified` events